### PR TITLE
Feature/get recursive children ids

### DIFF
--- a/contracts/Noncense.sol
+++ b/contracts/Noncense.sol
@@ -108,4 +108,47 @@ contract Noncense is Ownable {
     function getIdsByParentId(uint id, uint page, int offset) public view returns (uint[] memory) {
         return _getIds(byParentIdIndex[id], page, offset);
     }
+
+    function getRecursiveChildrenIds(uint id) checkId(id) public view returns (uint[] memory) {
+        uint size = getRecursiveChildrenCounts(id);
+        uint[] memory ids = new uint[](size);
+        ids[0] = id;
+        _getRecursiveChildrenIds(id, ids, 0);
+        return ids;
+    }
+
+    function _getRecursiveChildrenIds(uint id, uint[] memory arr, uint start) internal view returns (uint) {
+        postOne memory p = post[id];
+
+        if(p.children == 0) {
+            return start;
+        }
+
+        uint[] memory childrenIds = byParentIdIndex[id];
+        for(uint i=0; i < childrenIds.length; i++) {
+            arr[start] = childrenIds[i];
+            start += 1;
+            start = _getRecursiveChildrenIds(childrenIds[i], arr, start);
+        }
+        return start;
+    }
+
+    function getRecursiveChildrenCounts(uint id) checkId(id) internal view returns (uint) {
+        postOne memory p = post[id];
+        if(p.children == 0) {
+            return 0;
+        }
+
+        uint count = p.children;
+        uint[] memory childrenIds = byParentIdIndex[id];
+        for(uint i=0; i < childrenIds.length; i++) {
+             count += getRecursiveChildrenCounts(childrenIds[i]);
+        }
+        return count;
+    }
+
+    modifier checkId(uint id) {
+        require(id >= 0 && id < post.length);
+        _;
+    }
 }

--- a/test/noncense.js
+++ b/test/noncense.js
@@ -1,14 +1,38 @@
 const Noncense = artifacts.require("./Noncense");
 
+let noncense;
 contract("Noncense", accounts => {
+  // Noncense.deployed() uses the same deployed contract in a file, which results in dependency between tests.
+  // Noncense.new() resets the contract each it block.
+  beforeEach(async () => { noncense = await Noncense.new() });
 
   it("newPost() should create new post with given contents", async () => {
-    const noncense = await Noncense.deployed();
-
     await noncense.newPost("Hello Noncense", 0, "", "");
 
     const post = await noncense.post.call(1);
-    assert.equal(post.body, "Hello Noncense");
+    expect(post.body).to.equal("Hello Noncense");
   });
 
+  it("getIdsByAuthor() should return post ids written by the author", async () => {
+    // accounts[0] is the default msg.sender who wrote the root post, so use another one.
+    const author = accounts[1];
+    await noncense.newPost("", 0, "", "", { from: author });
+    const postId = 1
+    const postIds = await noncense.getIdsByAuthor(author, 0, 0)
+
+    expect(postIds.map(x => x.toNumber())).to.eql([postId]);
+  });
+
+  it("getIdsByParentId() should return its children ids", async () => {
+    await noncense.newPost("I'm the parent post!", 0, "", "");
+    const parentId = 1
+
+    await noncense.newPost("I'm the most recent post!", parentId, "", "");
+    const childId = 2
+    const childIds = await noncense.getIdsByParentId(parentId, 0, 0)
+
+    // eql checks deep equality but equal checks strict equality.
+    // e.g. expect([1, 2]).not.to.equal([1,2]) because [1,2] !== [1,2]
+    expect(childIds.map(x => x.toNumber())).to.eql([childId]);
+  });
 });

--- a/test/noncense.js
+++ b/test/noncense.js
@@ -35,4 +35,14 @@ contract("Noncense", accounts => {
     // e.g. expect([1, 2]).not.to.equal([1,2]) because [1,2] !== [1,2]
     expect(childIds.map(x => x.toNumber())).to.eql([childId]);
   });
+
+  it("getRecursiveChildrenIds() should return recursive children ids in DFS order", async () => {
+    await noncense.newPost("I'm a father", 0, "", "");
+    await noncense.newPost("I'm an uncle", 0, "", "");
+    await noncense.newPost("I'm a son", 1, "", "");
+    await noncense.newPost("I'm a grandchild", 3, "", "");
+
+    const response = await noncense.getRecursiveChildrenIds(0)
+    expect(response.map(x => x.toNumber())).to.eql([1,3,4,2]);
+  });
 });


### PR DESCRIPTION
글 상세보기 페이지에서 댓글을 조회하면 댓글 개수만큼 API를 호출해야하는
문제가 예상됩니다. 따라서 한 번에 댓글들을 보기 좋게 깊이 우선 탐색 순서로
반환하려고 했습니다. 그런데 `ABIEncoderV2`를 사용하지 않으면 구조체 배열을
반환할 수 없었습니다. 일단 id 배열이라도 반환해봅니다.
```
TypeError: This type is only supported in the new experimental ABI encoder.
Use "pragma experimental ABIEncoderV2;" to enable the feature.
function getPostWithComments(uint id) public view returns (postOne[] memory) {
```